### PR TITLE
Update Guzzle to ^6.3 or ^7.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -28,6 +28,6 @@
         "ext-curl": "*",
         "ext-json": "*",
         "ext-mbstring": "*",
-        "guzzlehttp/guzzle": "^6.2"
+        "guzzlehttp/guzzle": "^6.3|^7.0"
     }
 }


### PR DESCRIPTION
Feature: Use Guzzle ^6.3 or ^7.0, to allow API to co-exist with other (more up to date) packages.